### PR TITLE
fix login redirects not working for admin pages

### DIFF
--- a/app/Http/Middleware/AdminSessionValidator.php
+++ b/app/Http/Middleware/AdminSessionValidator.php
@@ -14,7 +14,7 @@ class AdminSessionValidator
     public function handle(Request $request, Closure $next): Response
     {
         if (!$request->session()->has('id') || !$request->session()->has('isAdmin'))
-            return redirect('login'); // Proper messaging will come at a later stage, awaiting the front-end.
+            return redirect('login')->with('fail', 'invalidsession')->with('redirect', $request->path());
 
         if ($request->session()->get('isAdmin') != 1)
             abort('403');


### PR DESCRIPTION
when attempting to access admin pages (/admin/*) and not logged in, you're redirected to the login page. after logging in, you should be redirected back to those pages. you were not. this fixes this issue.