### PR TITLE
Stock bugfixes

### DIFF
--- a/app/Models/Brand.php
+++ b/app/Models/Brand.php
@@ -44,14 +44,14 @@ class Brand extends Model
     }
 
     public function categoryCount(): int {
-        return Category::where('brand_id', '=', $this->bid)->get()->count();
+        return Category::where('brand_id', '=', $this->bid)->where('deleted', '=', '0')->get()->count();
     }
 
     public function stockCount(): int {
         $amt = 0;
-        $categories = Category::where('brand_id', '=', $this->bid)->get();
+        $categories = Category::where('brand_id', '=', $this->bid)->where('deleted', '=', '0')->get();
         foreach ($categories as $category) {
-            $amt += Stock::where('category_id', '=', $category->cid)->get()->count();
+            $amt += Stock::where('category_id', '=', $category->cid)->where('deleted', '=', '0')->get()->count();
         }
 
         return $amt;

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -50,6 +50,6 @@ class Category extends Model
     }
 
     public function stockCount(): int {
-        return Stock::where('category_id', '=', $this->cid)->get()->count();
+        return Stock::where('category_id', '=', $this->cid)->where('deleted', '=', '0')->get()->count();
     }
 }

--- a/public/css/shop.css
+++ b/public/css/shop.css
@@ -173,8 +173,14 @@ label {
     object-fit: contain; /* Ensures image maintains aspect ratio */
 }
 
+.product-item h3.product-brand {
+    margin: 5px 0;
+}
+
+
 .product-item h3.product-name {
     margin: 5px 0;
+    color: white;
 }
 
 .product-item p.product-price {

--- a/resources/views/admin/stock/brands/delete.blade.php
+++ b/resources/views/admin/stock/brands/delete.blade.php
@@ -47,6 +47,9 @@
             </thead>
             <tbody>
             @foreach($categories as $category)
+                @if($category->deleted == 1)
+                    @continue
+                @endif
                 <tr>
                     <td>{{ $category->cid }}</td>
                     <td>{{ $category->brand->name }}</td>
@@ -71,7 +74,13 @@
             </thead>
             <tbody>
             @foreach($categories as $category)
+                @if($category->deleted == 1)
+                    @continue
+                @endif
                 @foreach($category->items as $stock)
+                    @if($stock->deleted == 1)
+                        @continue
+                    @endif
                     <tr>
                         <td>{{ $stock->id }}</td>
                         <td>{{ $stock->category->brand->name }}</td>

--- a/resources/views/admin/stock/categories/delete.blade.php
+++ b/resources/views/admin/stock/categories/delete.blade.php
@@ -49,6 +49,9 @@
             </thead>
             <tbody>
                 @foreach($category->items as $stock)
+                    @if($stock->deleted == 1)
+                        @continue
+                    @endif
                     <tr>
                         <td>{{ $stock->id }}</td>
                         <td>{{ $stock->category->brand->name }}</td>

--- a/resources/views/shop.blade.php
+++ b/resources/views/shop.blade.php
@@ -118,7 +118,7 @@
                             <div class="product-image-container">
                                 <img src="{{$stock->images->first()->image_path}}" alt="{{$stock->category->name}} {{$stock->name}}" class="product-image">
                             </div>
-                            <h3 class="product-name">{{$stock->category->brand->name}} {{$stock->category->name}}</h3>
+                            <h3 class="product-brand">{{$stock->category->brand->name}} {{$stock->category->name}}</h3>
                             <h3 class="product-name">{{$stock->name}}</h3>
                             <p class="product-price">£{{$stock->price}}</p>
                         </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -185,7 +185,13 @@ Route::get('/shop/brand/{id}', function(string $id) {
     $stockList = new Collection;
     $categories = $brand->categories;
     foreach($categories as $cat) {
+        if ($cat->deleted == 1)
+            continue;
+
         foreach($cat->items as $item) {
+            if ($item->deleted == 1 || $item->isOutOfStock())
+                continue;
+
             $stockList->push($item);
         }
     }


### PR DESCRIPTION
Fixed the following bugs:
- Deleted items showing on the 'browse by brand' page
- Out of stock items showing on the 'browse by brand' page
- Deleted stock and categories appearing on admin archive warnings (i.e. 'you're about to delete 2 products' when one of which is deleted so it should say '1 product')

and changed the following:
- Changed the colour of items on the shop page. Gold for brand and category, white for stock name.